### PR TITLE
Fix faulty Format import

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ the command line.
 - Assume that you have Python 2.7 or higher installed on your computer.
 - Clone this repo.
 - Sample data lives in the `data` folder.
-- In your terminal, navigate into the `app` directory. Run:
+- In your terminal, navigate into the `src` directory. Run:
 ```sh
 python app.py <path_to_data>
 ```

--- a/src/Account.py
+++ b/src/Account.py
@@ -3,8 +3,7 @@
 
 from datetime import datetime
 
-from Format import clean, dollar
-from Utils import BOOLEAN_LOOKUP
+from Utils import BOOLEAN_LOOKUP, clean, dollar
 
 CODES = {
     "checking": "c",


### PR DESCRIPTION
An obsolete module named `Format` was being imported into `Account.py`. This fixes the issue.